### PR TITLE
Add MIT LICENSE file

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2025 maru0014
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.


### PR DESCRIPTION
# MITライセンスファイルの追加

## 概要
プロジェクトにMITライセンスファイルを追加しました。

## 追加内容
- `LICENSE` - 標準的なMITライセンス条項
- 2025年の著作権表示
- README.mdで言及されているライセンスとの整合性を確保

## 目的
- オープンソースプロジェクトとしての適切なライセンス表示
- GitHubでのライセンス自動認識対応
- 法的な明確性の確保

## ライセンス内容
- **自由な使用**: 商用・非商用問わず自由に使用可能
- **変更・配布**: ソースコードの変更・配布が可能
- **著作権表示**: ライセンス条項と著作権表示の保持が必要
- **無保証**: ソフトウェアの品質・動作に関する保証なし

READMEで既に「MITライセンスの下で公開」と記載していたため、実際のライセンスファイルを追加してプロジェクトを完成させました。