### PR TITLE
Remove sakura-editor from winget applications

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ windows-kitting-workflow/
 ### 基本アプリケーション
 - **開発ツール**: PowerShell 7, Git, Visual Studio Code
 - **ユーティリティ**: 7-Zip, PowerToys  
-- **生産性**: Sakura Editor, Google 日本語入力, Adobe Acrobat Reader
+- **生産性**: Google 日本語入力, Adobe Acrobat Reader
 - **ブラウザ**: Google Chrome, Mozilla Firefox
 - **メディア**: VLC Media Player
 - **コミュニケーション**: Microsoft Teams, Zoom

--- a/config/applications.json
+++ b/config/applications.json
@@ -21,8 +21,7 @@
       "installMethod": "winget",
       "packageId": "Git.Git",
       "args": []
-    },
-    {
+    },    {
       "id": "vscode",
       "name": "Visual Studio Code",
       "description": "Lightweight code editor",
@@ -31,17 +30,6 @@
       "enabled": true,
       "installMethod": "winget",
       "packageId": "Microsoft.VisualStudioCode",
-      "args": []
-    },
-    {
-      "id": "sakura-editor",
-      "name": "Sakura Editor",
-      "description": "Lightweight Japanese text editor",
-      "category": "Productivity",
-      "priority": 2,
-      "enabled": true,
-      "installMethod": "winget",
-      "packageId": "SakuraEditor.SakuraEditor",
       "args": []
     },
     {

--- a/docs/Application-Management.md
+++ b/docs/Application-Management.md
@@ -17,7 +17,6 @@ Windows Kitting Workflowでは、JSONベースの設定ファイルを使用し�
 - **PowerToys**: Microsoft製ユーティリティ集
 
 ### 生産性
-- **Sakura Editor**: 軽量日本語対応テキストエディタ
 - **Google 日本語入力**: 日本語入力システム
 - **Adobe Acrobat Reader**: PDF閲覧・編集
 
@@ -177,16 +176,6 @@ EXEファイルを使用したインストール
 ### 日本語環境に特化したアプリケーション例
 
 ```json
-{
-  "id": "sakura-editor",
-  "name": "Sakura Editor",
-  "description": "軽量日本語対応テキストエディタ",
-  "category": "Productivity",
-  "priority": 2,
-  "enabled": true,
-  "installMethod": "winget",
-  "packageId": "SakuraEditor.SakuraEditor"
-},
 {
   "id": "google-japanese-input",
   "name": "Google 日本語入力",


### PR DESCRIPTION
## 概要
wingetでsakura-editorが利用できないため、アプリケーション設定から削除しました。

## 変更内容
- `config/applications.json`からsakura-editorエントリを削除
- `README.md`の生産性アプリケーション一覧からSakura Editorを削除
- `docs/Application-Management.md`からSakura Editorの説明とJSONサンプルを削除

## 理由
wingetでSakura Editorパッケージが利用できないため、自動インストール対象から除外する必要がありました。

## テスト
- [ ] アプリケーション設定の読み込みが正常に動作することを確認
- [ ] ドキュメントの整合性を確認