### PR TITLE
fix: enforce CRLF line endings for all files via .gitattributes

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto
+* eol=crlf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,2 +1,9 @@
-* text=auto
-* eol=crlf
+* text=auto eol=crlf
+*.png binary
+*.jpg binary
+*.gif binary
+*.exe binary
+*.zip binary
+*.tar binary
+*.gz binary
+*.pdf binary


### PR DESCRIPTION
全ファイルの改行コードをCRLFに統一し、.gitattributesで明示的に管理するようにしました。Windows専用プロジェクトのため、LF混入を防止します。