### PR TITLE
Fix: 管理者権限実行時のカレントディレクトリ問題を修正

### DIFF
--- a/unblock-files.bat
+++ b/unblock-files.bat
@@ -2,8 +2,11 @@
 rem ファイルのセキュリティブロックを一括解除するバッチファイル
 echo ファイルのセキュリティブロック解除を開始します...
 
+rem バッチファイルがあるディレクトリに移動
+cd /d "%~dp0"
+
 rem PowerShellスクリプトを実行
-powershell -ExecutionPolicy Bypass -File "%~dp0scripts\Unblock-AllFiles.ps1" -Recurse
+powershell -ExecutionPolicy Bypass -File "scripts\Unblock-AllFiles.ps1" -Recurse
 
 echo.
 echo 処理が完了しました。


### PR DESCRIPTION
## 概要
Issue #13 で報告された、`unblock-files.bat` を管理者権限で実行した際にカレントディレクトリが `C:\WINDOWS\system32` になってしまう問題を修正しました。

## 変更内容
- `unblock-files.bat` の冒頭に `cd /d "%~dp0"` を追加
- PowerShellスクリプト実行時のパス指定を絶対パスから相対パスに変更

## 修正前
```batch
powershell -ExecutionPolicy Bypass -File "%~dp0scripts\Unblock-AllFiles.ps1" -Recurse
```

## 修正後
```batch
rem バッチファイルがあるディレクトリに移動
cd /d "%~dp0"

rem PowerShellスクリプトを実行
powershell -ExecutionPolicy Bypass -File "scripts\Unblock-AllFiles.ps1" -Recurse
```

## 効果
- 管理者権限で実行しても正しいディレクトリで処理が実行されるようになります
- 通常権限での実行にも影響はありません

## テスト
- 管理者権限での実行確認済み
- 通常権限での実行確認済み

Fixes #13