### PR TITLE
Fix completion marker path

### DIFF
--- a/scripts/Common-WorkflowHelpers.ps1
+++ b/scripts/Common-WorkflowHelpers.ps1
@@ -120,5 +120,7 @@ function Get-CompletionMarkerPath {
     param(
         [Parameter(Mandatory = $true)]
         [string]$TaskName
-    )    return Get-WorkflowPath -PathType "Status" -SubPath "$TaskName.completed"
+    )
+
+    return Get-WorkflowPath -PathType "Status" -SubPath "${TaskName}.completed"
 }


### PR DESCRIPTION
## Summary
- fix completion marker string expansion

## Testing
- `pwsh -NoLogo -Command "Write-Output 'test'"` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_688d2fd844cc832fa4f5424009fd35ee