### PR TITLE
fix(windows-update): 無人実行で再起動プロンプト抑止 (#30)

### DIFF
--- a/config/workflow.json
+++ b/config/workflow.json
@@ -159,7 +159,7 @@
           "KBArticleID": [],
           "NotKBArticleID": [],
           "Force": true,
-          "RebootIfRequired": true
+          "RebootIfRequired": false
         },
         "completionCheck": {
           "type": "file",

--- a/scripts/setup/windows-update.ps1
+++ b/scripts/setup/windows-update.ps1
@@ -177,9 +177,8 @@ function Install-WindowsUpdates {
 
 		$installParams = @{
 			'AcceptAll'  = $true
-			'AutoReboot' = $false
-			'Verbose'    = $true
 			'Install'    = $true
+			'Verbose'    = $true
 		}
 
 		if ($MicrosoftUpdate) {
@@ -192,6 +191,14 @@ function Install-WindowsUpdates {
 
 		if ($NotKBArticleID -and $NotKBArticleID.Count -gt 0) {
 			$installParams['NotKBArticleID'] = $NotKBArticleID
+		}
+
+		# 再起動ポリシーの適用（無人実行のため再起動確認を抑止）
+		if ($RebootIfRequired) {
+			$installParams['AutoReboot'] = $true
+		}
+		else {
+			$installParams['IgnoreReboot'] = $true
 		}
 
 		# アップデートのダウンロードとインストール


### PR DESCRIPTION
PSWindowsUpdate 実行時の再起動確認を無人化し、再起動制御をワークフロー側へ集約。変更点: 1) Get-WUInstall に AutoReboot/IgnoreReboot を条件適用 2) workflow.json の windows-update パラメータ RebootIfRequired=false に統一。関連: #30 https://github.com/maru0014/windows-kitting-workflow/issues/30